### PR TITLE
add system.get_host_name_from_environment and bump version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="socrate",
-    version="0.2.0",
+    version="0.2.1",
     description="Socrate daemon utilities",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/socrate/system.py
+++ b/socrate/system.py
@@ -30,3 +30,13 @@ def get_host_address_from_environment(name, default):
     if "{}_ADDRESS".format(name) in environ:
         return environ.get("{}_ADDRESS".format(name))
     return resolve_address(environ.get("HOST_{}".format(name), default))
+
+def get_host_name_from_environment(name, default):
+    """ This function looks up an envionment variable ``{{ name }}_ADDRESS``.
+    If it's defined, it is returned unmodified. If it's undefined, an environment
+    variable ``HOST_{{ name }}`` is looked up and returned.
+    If this is also not defined, the default is returned.
+    """
+    if "{}_ADDRESS".format(name) in environ:
+        return environ.get("{}_ADDRESS".format(name))
+    return resolve_address(environ.get("HOST_{}".format(name), default))


### PR DESCRIPTION
Mailu uses system.get_host_address_from_environment and puts in IP addresses everywhere,
but restarting docker containers does not guarantee that the IP will stay the same. we add system.get_host_name_from_environment and bump version to 0.2.1 to be able to add a PR to mailu to replace ip addresses with container names everywhere.